### PR TITLE
Utilise string formatting, minor testing improvements

### DIFF
--- a/basic_api_service/main.py
+++ b/basic_api_service/main.py
@@ -16,7 +16,7 @@ async def root():
 
 @basic_api_service.get("/time")
 async def get_time_and_date(timezone: str = DEFAULT_TIMEZONE):
-    return {"Time in " + timezone: time_and_date(timezone)}
+    return {f"Time in {timezone}": time_and_date(timezone)}
 
 
 def time_and_date(timezone: str):

--- a/basic_api_service/main_test.py
+++ b/basic_api_service/main_test.py
@@ -1,13 +1,8 @@
 from fastapi.testclient import TestClient
-from main import (
-    basic_api_service,
-    time_and_date,
-    TITLE_MESSAGE,
-    TIME_FORMAT,
-    DEFAULT_TIMEZONE,
-)
+from main import basic_api_service, TITLE_MESSAGE, DEFAULT_TIMEZONE
 from freezegun import freeze_time
 from datetime import datetime
+from http import HTTPStatus
 import pytz
 
 client = TestClient(basic_api_service)
@@ -15,22 +10,22 @@ client = TestClient(basic_api_service)
 
 def test_root_message():
     response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == HTTPStatus.OK
     assert response.json()["message"] == TITLE_MESSAGE
 
 
 @freeze_time("2023-01-01 00:00:00")
 def test_get_time_and_date():
+    expected_response = "13:00:00 01/01/2023"
     response = client.get("/time")
-    expected_response = time_and_date(DEFAULT_TIMEZONE)
-    assert response.status_code == 200
-    assert response.json()["Time in Pacific/Auckland"] == expected_response
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()[f"Time in {DEFAULT_TIMEZONE}"] == expected_response
 
 
 @freeze_time("2023-01-01 00:00:00")
 def test_get_time_and_date_with_timezone():
     test_timezone = "Europe/London"
+    expected_response = "00:00:00 01/01/2023"
     response = client.get("/time/?timezone=" + test_timezone)
-    expected_response = time_and_date(test_timezone)
-    assert response.status_code == 200
-    assert response.json()["Time in Europe/London"] == expected_response
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()[f"Time in {test_timezone}"] == expected_response


### PR DESCRIPTION
* Use string formatting to construct string in API
* Updating tests to actuallt test timezone usage
* Using HTTPStatus for status code asserting instead of hardcoded ints